### PR TITLE
Refactor Work component and update alt text in skipognaust pages

### DIFF
--- a/components/work.tsx
+++ b/components/work.tsx
@@ -27,7 +27,7 @@ interface WorkProps {
 const containerStyles = cva('my-10 w-full rounded grid grid-cols-1 bg-ll-sandy border-solid border border-ll-sandy-100 dark:border-ll-blue-900 dark:bg-ll-blue-900', {
   variants: {
     size: {
-      default: 'h-[630px] md:h-[700px]',
+      default: 'min-h-[630px] md:min-h-[700px]',
     },
   },
   defaultVariants: {
@@ -47,12 +47,12 @@ const viewerContainerStyles = cva('w-full relative dark:bg-ll-blue-950 z-0 flex-
   },
 });
 
-const childrenContainerStyles = cva('p-5 w-full bg-ll-blue-900 text-white dark:nx-bg-primary-400/10 flex flex-col justify-between');
+const childrenContainerStyles = cva('p-5 w-full dark:bg-ll-blue-950 text-white flex flex-col justify-between');
 
 const buttonStyles = cva('rounded-full self-end px-5 py-2 m-5 bg-ll-red dark:bg-red-700');
 
 const Work = ({ children, id, url, marcus, config }: WorkProps) => {
-  const [API_URL, setApiUrl] = useState(FALLBACK_API_URL);
+  const [apiUrl, setApiUrl] = useState(FALLBACK_API_URL);
 
   useEffect(() => {
     const checkProdApi = async () => {
@@ -69,7 +69,7 @@ const Work = ({ children, id, url, marcus, config }: WorkProps) => {
     checkProdApi();
   }, []);
 
-  const manifestId = id ? `${API_URL}/items/${id}?as=iiif` : url;
+  const manifestId = id ? `${apiUrl}/items/${id}?as=iiif` : url;
   const { locale } = useRouter();
 
   const buttonText = locale === 'no' ? 'Se mer i Marcus' : 'Read more in Marcus';

--- a/pages/landevernsbolken/skipognaust.en.mdx
+++ b/pages/landevernsbolken/skipognaust.en.mdx
@@ -3,13 +3,14 @@ title: Ships and boathouses
 description: About the building and the use of the levy ships
 tags: null
 image: /images/card-images/skipognaust.jpg
-alt: Boathouses by the fjord at Vikøyri.
+alt: On the obverse of Bergen's seal a medieval sailship is represented.
 ---
 
 import Blockquote from 'components/blockquote';
 import Container from 'components/container';
 import Spacer from 'components/spacer';
-import Figure from 'components/figure';
+import Work from 'components/work';
+
 
 # Ships and boathouses
 
@@ -33,9 +34,6 @@ import Figure from 'components/figure';
     The food on board was obviously important for morale, for a cook who prepared bad food would receive corporal punishment – but not so severe that he suffered permanent injuries.
 </Container>
 
-<Figure
-    image="/images/landevernsbolken/ubb-bs-fol-01039-006-b_xl.jpg"
-    title="Ship in research course (?) in Herdlasundet. Unknown photographer - Picture Collection, UBB."
-    alt="Ship in research course (?)."
->
-</Figure>
+<Work id="ubb-kk-1318-1244" marcus="https://marcus.uib.no/instance/photograph/ubb-kk-1318-1244.html">
+Mangler bildetekst
+</Work>

--- a/pages/landevernsbolken/skipognaust.no.mdx
+++ b/pages/landevernsbolken/skipognaust.no.mdx
@@ -3,13 +3,13 @@ title: Skip og naust
 description: Om bygging og bruk av leidangsskip
 tags: null
 image: /images/card-images/skipognaust.jpg
-alt: Nøster ved fjorden på Vikøyri.
+alt: Forsiden av Bergens bysegl viser et seilskip fra middelalderen.
 ---
 
 import Blockquote from 'components/blockquote';
 import Container from 'components/container';
 import Spacer from 'components/spacer';
-import Figure from 'components/figure';
+import Work from 'components/work';
 
 
 # Skip og naust
@@ -27,9 +27,6 @@ import Figure from 'components/figure';
     For grove forsømmelser kunne man bli lyst fredløs. Maten om bord var tydeligvis viktig for moralen, for en kokk som laget dårlig mat skulle ha fysisk avstraffelse, men ikke så hard medfart at han fikk varige mén.
 </Container>
 
-<Figure
-    image="/images/landevernsbolken/ubb-bs-fol-01039-006-b_xl.jpg"
-    title="Skip under forskningskurs (?) i Herdlasundet. Ukjent fotograf - Billedsamlingen, UBB."
-    alt="Skip under forskningskurs (?)."
->
-</Figure>
+<Work id="ubb-kk-1318-1244" marcus="https://marcus.uib.no/instance/photograph/ubb-kk-1318-1244.html">
+Mangler bildetekst
+</Work>


### PR DESCRIPTION
- Changed height properties to minimum height in Work component styles.
- Updated the import of the Figure component to use the Work component in skipognaust.en.mdx and skipognaust.no.mdx.
- Modified alt text for images in both language versions to better reflect content.